### PR TITLE
Adopt to v0.14 compat layer

### DIFF
--- a/fluent-plugin-kubernetes.gemspec
+++ b/fluent-plugin-kubernetes.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 4.0"
+  spec.add_development_dependency "test-unit", "~> 3.2.0"
   spec.add_development_dependency "copyright-header"
   spec.add_development_dependency "minitest-vcr"
   spec.add_development_dependency "webmock"

--- a/lib/fluent/plugin/out_kubernetes.rb
+++ b/lib/fluent/plugin/out_kubernetes.rb
@@ -19,6 +19,11 @@
 class Fluent::KubernetesOutput < Fluent::Output
   Fluent::Plugin.register_output('kubernetes', self)
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   config_param :container_id, :string
   config_param :tag, :string
   config_param :kubernetes_pod_regex, :string, default: '^[^_]+_([^\.]+)\.[^_]+_([^\.]+)\.([^\.]+)'
@@ -36,9 +41,9 @@ class Fluent::KubernetesOutput < Fluent::Output
 
   def emit(tag, es, chain)
     es.each do |time,record|
-      Fluent::Engine.emit('kubernetes',
-                          time,
-                          enrich_record(tag, record))
+      router.emit('kubernetes',
+                  time,
+                  enrich_record(tag, record))
     end
 
     chain.next


### PR DESCRIPTION
Hi, I've tried to use this plugin with Fluentd v0.14 Compat layer, but I found a bug which is caused by `Fluent::Engine#emit` directly.
Otherwise, it seems OK to use with Fluentd v0.14' Compat layer.
Could you take a look?

Thanks,